### PR TITLE
Complete Name should be descriptive even when new iPhones get released

### DIFF
--- a/Pod/Classes/Deviice.swift
+++ b/Pod/Classes/Deviice.swift
@@ -371,7 +371,12 @@ public struct Deviice {
         }
         
         self.model = self.type.rawValue
-        self.completeName = self.model + " - " + self.connectivity.rawValue + " - " + self.size.rawValue
+        
+        if self.type == .unknown {
+            self.completeName = identifier + " - " + self.connectivity.rawValue + " - " + self.size.rawValue
+        }else {
+            self.completeName = self.model + " - " + self.connectivity.rawValue + " - " + self.size.rawValue
+        }
     }
     
     


### PR DESCRIPTION
It took a while, but we recently noticed that the new iPhone X (and 8, 8+) would be named as "Unknown-Unknown-Unknown" when we use an old version of the library. 
In some cases this may be okay, when you check the `type` or `model` before submitting that name to the server. I think it would be a nice addition if the identifier is added to the complete name if the device is unknown in the current state of the library. 
This would prevent in some cases that the app needs to be updated just because new phones came out which are not on the list. 

I hope you agree to my addition 