### PR TITLE
fixed incorrect iPhone13,3 (changed from pro max to pro), and added i…

### DIFF
--- a/Sources/Deviice/Deviice.swift
+++ b/Sources/Deviice/Deviice.swift
@@ -367,6 +367,12 @@ public struct Deviice {
             self.year = 2020
             
         case "iPhone13,3":
+            self.type = .iPhone12Pro
+            self.size = .screen6Dot1Inches
+            self.connectivity = .wiFi5G
+            self.year = 2020
+            
+        case "iPhone13,4":
             self.type = .iPhone12ProMax
             self.size = .screen6Dot7Inches
             self.connectivity = .wiFi5G


### PR DESCRIPTION
Based on data from https://www.theiphonewiki.com/wiki/Models, iPhone13,3 is incorrectly returning iPhone 12 Pro Max, should have been just iPhone 12 Pro.  iPhone 13,4 was missing altogether so added it as Pro Max.